### PR TITLE
feat: 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeedproject/post/controller/PostController.java
@@ -3,13 +3,16 @@ package com.example.newsfeedproject.post.controller;
 import com.example.newsfeedproject.post.dto.PostPageResponseDto;
 import com.example.newsfeedproject.post.dto.PostRequestDto;
 import com.example.newsfeedproject.post.dto.PostResponseDto;
+import com.example.newsfeedproject.post.dto.PostUpdateRequestDto;
+import com.example.newsfeedproject.post.dto.PostUpdateResponseDto;
 import com.example.newsfeedproject.post.service.PostService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,5 +46,22 @@ public class PostController {
         PostPageResponseDto pageResponseDto = postService.getPostsPaginated(page - 1, size);
 
         return new ResponseEntity<>(pageResponseDto, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<PostUpdateResponseDto> updatePost(
+        HttpServletRequest request,
+        @PathVariable Long postId,
+        @RequestBody PostUpdateRequestDto requestDto
+    ){
+        PostUpdateResponseDto responseDto = postService.updatePost(
+            request,
+            postId,
+            requestDto.getTitle(),
+            requestDto.getContent(),
+            requestDto.getPassword()
+        );
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/newsfeedproject/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/example/newsfeedproject/post/dto/PostUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.newsfeedproject.post.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostUpdateRequestDto {
+
+    private final String title;
+    private final String content;
+    private final String password;
+
+    public PostUpdateRequestDto(String title, String content, String password) {
+        this.title = title;
+        this.content = content;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/post/dto/PostUpdateResponseDto.java
+++ b/src/main/java/com/example/newsfeedproject/post/dto/PostUpdateResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.newsfeedproject.post.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class PostUpdateResponseDto {
+
+    private final Long postId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime updatedAt;
+
+    public PostUpdateResponseDto(Long postId, String title, String content,
+        LocalDateTime updatedAt) {
+        this.postId = postId;
+        this.title = title;
+        this.content = content;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/newsfeedproject/post/entity/Post.java
+++ b/src/main/java/com/example/newsfeedproject/post/entity/Post.java
@@ -22,9 +22,11 @@ public class Post extends TimeBaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 게시글 고유 식별자
 
+    @Setter
     @Column(nullable = false)
     private String title; // 게시글 제목
 
+    @Setter
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content; // 게시글 내용
 


### PR DESCRIPTION
HttpServletRequest를 통해 세션을 가져와
현재 로그인한 사용자의 id를 가져오고
PathVariable로 받아온 postId를 통해 수정할
Post를 조회 후 Post.getUser를 하여 해당 게시글을
작성한 User 객체를 받아온다.
해당 User객체의 id와 세션에서 받아온 id를 비교하여
동일하다면 비밀번호를 검증하고 게시글을 수정,저장 후
수정한 게시글의 내용을 반환하는 기능 추가